### PR TITLE
Check if MPC is defined before access

### DIFF
--- a/assets/js/klarna-onsite-messaging.js
+++ b/assets/js/klarna-onsite-messaging.js
@@ -131,6 +131,10 @@ jQuery( function($) {
 			});
 
 			$('form.cart').on('change', 'input.qty', function () {
+				if (typeof wc_price_calculator_params === 'undefined') {
+					return;
+				}
+
 				quantity = this.value
 				unit_price = parseFloat($('.product_price span').text()) // NaN - if the customer has not yet entered any units in the MPC fields.
 


### PR DESCRIPTION
The change is happening on an element that is part of the standard WC page. E.g., a non-MPC variable product  will trigger this change so we much check if MPC is defined before we try to access its properties.