### PR TITLE
Fix undefined index

### DIFF
--- a/klarna-onsite-messaging-for-woocommerce.php
+++ b/klarna-onsite-messaging-for-woocommerce.php
@@ -187,13 +187,11 @@ class Klarna_OnSite_Messaging_For_WooCommerce {
 	 * @return array
 	 */
 	public static function get_settings() {
-		if ( class_exists( 'WC_Klarna_Payments' ) ) {
-			return get_option( 'woocommerce_klarna_payments_settings' );
-		} elseif ( class_exists( 'Klarna_Checkout_For_WooCommerce' ) ) {
-			return get_option( 'woocommerce_kco_settings' );
-		} elseif ( class_exists( 'KCO' ) ) {
+		$settings = get_option( 'woocommerce_klarna_payments_settings' );
+		if ( empty( $settings ) ) {
 			return get_option( 'woocommerce_kco_settings' );
 		}
+		return $settings;
 	}
 
 	/**

--- a/klarna-onsite-messaging-for-woocommerce.php
+++ b/klarna-onsite-messaging-for-woocommerce.php
@@ -43,8 +43,8 @@ class Klarna_OnSite_Messaging_For_WooCommerce {
 	 * Class cunstructor.
 	 */
 	public function __construct() {
-		add_filter( 'wc_gateway_klarna_payments_settings', array( $this, 'extend_settings' ) );
-		add_filter( 'kco_wc_gateway_settings', array( $this, 'extend_settings' ) );
+		add_filter( 'wc_gateway_klarna_payments_settings', array( __CLASS__, 'extend_settings' ) );
+		add_filter( 'kco_wc_gateway_settings', array( __CLASS__, 'extend_settings' ) );
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 		add_filter( 'script_loader_tag', array( $this, 'load_klarna_async' ), 10, 3 );
 
@@ -67,7 +67,7 @@ class Klarna_OnSite_Messaging_For_WooCommerce {
 	 * @param array $settings The plugin settings.
 	 * @return array $settings
 	 */
-	public function extend_settings( $settings ) {
+	public static function extend_settings( $settings ) {
 		$settings['onsite_messaging']                  = array(
 			'title' => 'Klarna On-Site Messaging',
 			'type'  => 'title',
@@ -187,11 +187,13 @@ class Klarna_OnSite_Messaging_For_WooCommerce {
 	 * @return array
 	 */
 	public static function get_settings() {
-		$settings = get_option( 'woocommerce_klarna_payments_settings' );
-		if ( empty( $settings ) ) {
-			return get_option( 'woocommerce_kco_settings' );
+		if ( isset( WC()->payment_gateways->payment_gateways()['kco'] ) ) {
+			$settings = get_option( 'woocommerce_kco_settings' );
+		} elseif ( class_exists( 'WC_Klarna_Payments' ) ) {
+			$settings = get_option( 'woocommerce_klarna_payments_settings', array() );
 		}
-		return $settings;
+
+		return wp_parse_args( $settings, self::extend_settings( array() ) );
 	}
 
 	/**


### PR DESCRIPTION
Currently, when retrieving the KOM settings, we only check if KP exists when retrieving the KP settings even if it is not enabled (but is activated) although it is KCO that is enabled and is in use.  This leads to undefined index access since get_option returns `false`.

Check if we get back any settings from KP, otherwise, default to KCO settings.

```
PHP Notice:  Trying to access array offset on value of type bool in /var/www/html/wp-content/plugins/klarna-onsite-messaging-for-woocommerce/klarna-onsite-messaging-for-woocommerce.php on line 236

PHP Notice:  Trying to access array offset on value of type bool in /var/www/html/wp-content/plugins/klarna-onsite-messaging-for-woocommerce/classes/class-klarna-onsite-messaging-cart-page.php on line 71
```