### PR TITLE
Declare HPOS compatibility

### DIFF
--- a/klarna-onsite-messaging-for-woocommerce.php
+++ b/klarna-onsite-messaging-for-woocommerce.php
@@ -63,6 +63,19 @@ class Klarna_OnSite_Messaging_For_WooCommerce {
 		}
 
 		$this->set_data_client_id();
+		add_action( 'before_woocommerce_init', array( $this, 'declare_wc_compatibility' ) );
+	}
+
+		/**
+		 * Declare compatibility with WooCommerce features.
+		 *
+		 * @return void
+		 */
+	public function declare_wc_compatibility() {
+		// Declare HPOS compatibility.
+		if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
+			\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
+		}
 	}
 
 	/**


### PR DESCRIPTION
As described in the [recipe book](https://github.com/woocommerce/woocommerce/wiki/High-Performance-Order-Storage-Upgrade-Recipe-Book):
- `get_post( $post_id )` → `wc_get_order( $post_id )`
- `update_post_meta` → `WC_Order::update_meta_data`
- `add_post_meta` → `WC_Order::add_meta_data`
- `delete_post_meta` → `WC_Order::delete_meta_data`

Furthermore, where applicable, if a method is available for the meta field, that will be used in favor of retrieving it through the meta data function.  For example,  

```
get_post_meta($order_id, '_transaction_id', true)
```
is replaced with 
```
WC_Order::get_transaction_id()
```

If a meta data function is available, and update_meta_data is still used for that meta data, WooCommerce will warn about directly modifying internal meta data.

Note:
1. The HPOS-related methods _must_ be followed at some point by a `save()` call.
2. The recipe book does not seem to reference a replacement for `get_post_meta`, but this should be replaced by `WC_Order::get_meta`.