### PR TITLE
Handle cart total change

### DIFF
--- a/assets/js/klarna-onsite-messaging.js
+++ b/assets/js/klarna-onsite-messaging.js
@@ -14,9 +14,14 @@ jQuery( function($) {
 			return true;
 		},
 
-		update_total_cart: function() {
-			let price = Math.round($("#kosm_cart_total").val() * 100);
-			klarna_onsite_messaging.update_total_price(price)
+		update_total_cart: function (price) {
+			if (!price) {
+				price = Math.round($("#kosm_cart_total").val());
+			}
+
+			if (!isNaN(price)) {
+				klarna_onsite_messaging.update_total_price(price * 100)
+			}
 		},
 
 		update_total_variation: function( variation ) {
@@ -102,8 +107,20 @@ jQuery( function($) {
 			});
 			
 			$(document.body).on("updated_cart_totals", function () {
-				klarna_onsite_messaging.update_total_cart();
+				$.ajax({
+					url: klarna_onsite_messaging_params.get_cart_total_url,
+					type: 'GET',
+					dataType: 'json',
+					success: function (response) {
+						console.log('success', response)
+						klarna_onsite_messaging.update_total_cart(response.data);
+					},
+					error: function (response) {
+						console.log(response);
+					}
+				});
 			});
+
 			$(document).on( 'found_variation', function( e, variation ) {
 				klarna_onsite_messaging.update_total_variation( variation );
 			});

--- a/klarna-onsite-messaging-for-woocommerce.php
+++ b/klarna-onsite-messaging-for-woocommerce.php
@@ -43,6 +43,8 @@ class Klarna_OnSite_Messaging_For_WooCommerce {
 	 * Class cunstructor.
 	 */
 	public function __construct() {
+		add_action( 'wc_ajax_kosm_get_cart_total', array( $this, 'get_cart_total' ) );
+
 		add_filter( 'wc_gateway_klarna_payments_settings', array( $this, 'extend_settings' ) );
 		add_filter( 'kco_wc_gateway_settings', array( $this, 'extend_settings' ) );
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
@@ -52,6 +54,19 @@ class Klarna_OnSite_Messaging_For_WooCommerce {
 		add_action( 'plugins_loaded', array( $this, 'include_files' ) );
 		add_action( 'plugins_loaded', array( $this, 'init' ) );
 		add_action( 'widgets_init', array( $this, 'register_klarna_osm_widget' ) );
+	}
+
+	/**
+	 * Retrieve the cart total amount.
+	 *
+	 * @return void
+	 */
+	public function get_cart_total() {
+		if ( ! isset( WC()->cart ) ) {
+			wp_send_json_error( 'no_cart' );
+		}
+
+		wp_send_json_success( WC()->cart->total );
 	}
 
 	/**
@@ -256,7 +271,10 @@ class Klarna_OnSite_Messaging_For_WooCommerce {
 
 		wp_register_script( 'klarna_onsite_messaging', plugins_url( '/assets/js/klarna-onsite-messaging.js', __FILE__ ), array( 'jquery' ), WC_KLARNA_ONSITE_MESSAGING_VERSION );
 
-		$localize = array( 'ajaxurl' => admin_url( 'admin-ajax.php' ) );
+		$localize = array(
+			'ajaxurl'            => admin_url( 'admin-ajax.php' ),
+			'get_cart_total_url' => WC_AJAX::get_endpoint( 'kosm_get_cart_total' ),
+		);
 
 		if ( isset( $_GET['osmDebug'] ) && '1' === $_GET['osmDebug'] ) {
 			$localize['debug_info'] = array(


### PR DESCRIPTION
Previously, when customers changed the shipping option, the `#kosm_cart_total` was unset, resulting in a NaN value when fetching the price.

With this pull request (PR), this issue is addressed by retrieving the cart total directly from the server using AJAX when it is modified. Also added safeguards to prevent passing NaN values to KOSM.