### PR TITLE
Fix OSM being empty until variant is selected

### DIFF
--- a/assets/js/klarna-onsite-messaging.js
+++ b/assets/js/klarna-onsite-messaging.js
@@ -1,8 +1,7 @@
 jQuery( function($) {
 	var klarna_onsite_messaging = {
 		update_iframe: function() {
-			window.kudt = window.kudt || [];
-			window.kudt.push({eventName: 'refresh-placements'});
+			window.Klarna.OnsiteMessaging.refresh()
 			$('klarna-placement').show();
 		},
 
@@ -99,6 +98,7 @@ jQuery( function($) {
 				}
 
 				klarna_onsite_messaging.debug_info();
+				klarna_onsite_messaging.update_iframe();
 			});
 			
 			$(document.body).on("updated_cart_totals", function () {


### PR DESCRIPTION
Updating the iframe on `init` solves the issue with OSM not displaying until the customer picks a variant.

`window.KlarnaOnsiteService.push({ eventName: 'refresh-placements'})` has been deprecated in favor of `window.Klarna.OnsiteMessaging.refresh()`.