### PR TITLE
Add filter to force locale regardless of currency

### DIFF
--- a/includes/klarna-onsite-messaging-functions.php
+++ b/includes/klarna-onsite-messaging-functions.php
@@ -196,7 +196,7 @@ function kosm_get_locale_for_currency() {
 		default:
 			$locale = false;
 	}
-	return $locale;
+	return apply_filters( 'kosm_locale', $locale );
 }
 
 /**


### PR DESCRIPTION
The [`kosm_default_euro_locale` filter](https://docs.krokedil.com/klarna-for-woocommerce/additional-klarna-plugins/klarna-on-site-messaging/#force-locale-to-a-specific-country) that is used for overriding the locale, only applies if the store currency is EURO.

- Added a currency-independent filter for overriding the locale.